### PR TITLE
more auto-labeling functionality

### DIFF
--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -58,6 +58,36 @@ public class GithubAPI {
     }
   }
 
+  class func createComment(url: String, comment: String) {
+    let commentsURL = url + "/comments"
+    let bodyDict = ["body": comment]
+    do {
+      let request = GithubCURLRequest(commentsURL, .postString(try bodyDict.jsonEncodedString()))
+      addAPIHeaders(to: request)
+      let response = try request.perform()
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+        createComment(url: url, comment: comment)
+      }
+      LogFile.info("request result for createComment: \(response.bodyString)")
+    } catch {
+      LogFile.error("error: \(error) desc: \(error.localizedDescription)")
+    }
+  }
+
+  class func editIssue(url: String, issueEdit: [String: Any]) {
+    do {
+      let request = GithubCURLRequest(url, .httpMethod(.patch), .postString(try issueEdit.jsonEncodedString()))
+      addAPIHeaders(to: request)
+      let response = try request.perform()
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+        editIssue(url: url, issueEdit: issueEdit)
+      }
+      LogFile.info("request result for editIssue: \(response.bodyString)")
+    } catch {
+      LogFile.error("error: \(error) desc: \(error.localizedDescription)")
+    }
+  }
+
   class func setLabelsForAllIssues() {
     do {
       guard let repoPath = ProcessInfo.processInfo.environment["GITHUB_REPO_PATH"] else {

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -42,6 +42,12 @@ public class GithubAPI {
   static let retryCount = 0
   static var lastGithubAccess = time(nil)
 
+
+  /// This method adds labels to a Github issue through the API.
+  ///
+  /// - Parameters:
+  ///   - url: The url of the issue as a String
+  ///   - labels: The labels to add to the issue
   class func addLabelsToIssue(url: String, labels: [String]) {
     LogFile.debug(labels.description)
     let labelsURL = url + "/labels"
@@ -58,6 +64,12 @@ public class GithubAPI {
     }
   }
 
+
+  /// This method creates and adds a comment to a Github issue through the API.
+  ///
+  /// - Parameters:
+  ///   - url: The url of the issue as a String
+  ///   - comment: The comment text
   class func createComment(url: String, comment: String) {
     let commentsURL = url + "/comments"
     let bodyDict = ["body": comment]
@@ -74,6 +86,13 @@ public class GithubAPI {
     }
   }
 
+
+  /// This method edits an existing Github issue through the API.
+  ///
+  /// - Parameters:
+  ///   - url: The url of the issue as a String
+  ///   - issueEdit: A dictionary where the keys are the items to edit in the issue, and the
+  ///                values are what they should be edited to.
   class func editIssue(url: String, issueEdit: [String: Any]) {
     do {
       let request = GithubCURLRequest(url, .httpMethod(.patch), .postString(try issueEdit.jsonEncodedString()))
@@ -88,6 +107,8 @@ public class GithubAPI {
     }
   }
 
+
+  /// This method bulk updates all the existing Github issues to have labels through the API.
   class func setLabelsForAllIssues() {
     do {
       guard let repoPath = ProcessInfo.processInfo.environment["GITHUB_REPO_PATH"] else {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -76,10 +76,10 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       var labelsToAdd = [String]()
       let diffURL = PRData.diff_url
       let paths = PRLabelAnalysis.getFilePaths(url: diffURL)
-      let labelsFromPaths = PRLabelAnalysis.grabLabelsFromPaths(paths: paths)
+      let labelsFromPaths = Set(PRLabelAnalysis.grabLabelsFromPaths(paths: paths))
       if (labelsFromPaths.count > 1) {
         //notify of changing multiple components
-        GithubAPI.createComment(url: PRData.issue_url, comment: "The PR is affecting multiple components.")
+        GithubAPI.createComment(url: PRData.issue_url, comment: "This PR affects multiple components.")
       }
       labelsToAdd.append(contentsOf: labelsFromPaths)
       if let titleLabel = PRLabelAnalysis.getTitleLabel(title: PRData.title) {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -76,9 +76,20 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       var labelsToAdd = [String]()
       let diffURL = PRData.diff_url
       let paths = PRLabelAnalysis.getFilePaths(url: diffURL)
-      labelsToAdd.append(contentsOf: PRLabelAnalysis.grabLabelsFromPaths(paths: paths))
+      let labelsFromPaths = PRLabelAnalysis.grabLabelsFromPaths(paths: paths)
+      if (labelsFromPaths.count > 1) {
+        //notify of changing multiple components
+        GithubAPI.createComment(url: PRData.issue_url, comment: "The PR is affecting multiple components.")
+      }
+      labelsToAdd.append(contentsOf: labelsFromPaths)
       if let titleLabel = PRLabelAnalysis.getTitleLabel(title: PRData.title) {
         labelsToAdd.append(titleLabel)
+      } else if labelsFromPaths.count == 1, let label = labelsFromPaths.first {
+        //update title
+        GithubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": label + PRData.title])
+        //notify of title change
+        GithubAPI.createComment(url: PRData.issue_url,
+                                comment: "Based on the changes, the title has been prefixed with \(label)")
       }
       if (labelsToAdd.count > 0) {
         GithubAPI.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))
@@ -93,6 +104,8 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       }
       if (labelsToAdd.count > 0) {
         GithubAPI.addLabelsToIssue(url: issueData.url, labels: Array(Set(labelsToAdd)))
+      } else {
+        GithubAPI.createComment(url: issueData.url, comment: "The title doesn't have a [Component] prefix.")
       }
     }
   }


### PR DESCRIPTION
* Now if a PR is touching more than one component, the submitter is notified with a comment by the bot about it
* If in a PR one component is affected but the title doesn't have a prefix, it will update the title and add a prefix. it also notifies the submitter about it.
* In an issue if a [component] prefix isn't in the title, the bot sends a message about it