### PR TITLE
Improved auto-labeling and title correcting

### DIFF
--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -130,14 +130,14 @@ public class GithubAPI {
           continue
         }
         var labelsToAdd = [String]()
-        if let titleLabel = PRLabelAnalysis.getTitleLabel(title: issueData.title) {
+        if let titleLabel = LabelAnalysis.getTitleLabel(title: issueData.title) {
           labelsToAdd.append(titleLabel)
         }
         if let PRDict = issue["pull_request"] as? [String: Any] {
           if let diffURL = PRDict["diff_url"] as? String, diffURL.count > 0 {
-            let paths = PRLabelAnalysis.getFilePaths(url: diffURL)
+            let paths = LabelAnalysis.getFilePaths(url: diffURL)
             LogFile.debug(paths.description)
-            labelsToAdd.append(contentsOf: PRLabelAnalysis.grabLabelsFromPaths(paths: paths))
+            labelsToAdd.append(contentsOf: LabelAnalysis.grabLabelsFromPaths(paths: paths))
           }
         }
         if (labelsToAdd.count > 0) {
@@ -164,7 +164,7 @@ public class GithubAPI {
         LogFile.error("You have not defined a GITHUB_REPO_PATH pointing to your repo in your app.yaml file")
         return pathNames
       }
-      let contentsAPIPath = "/repos/" + repoPath + "/contents/" + relativePath
+      let contentsAPIPath = githubBaseURL + "/repos/" + repoPath + "/contents/" + relativePath
       let request = GithubCURLRequest(contentsAPIPath)
       addAPIHeaders(to: request)
       let response = try request.perform()

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -150,6 +150,13 @@ public class GithubAPI {
     }
   }
 
+
+  /// This method receives a relative path inside the repository source code and receives from the Github API
+  /// a JSON containing an array of dictionaries showing the files info in that directory. We
+  /// then return a list of all the file names that are directories.
+  ///
+  /// - Parameter relativePath: The relative path inside the repository source code
+  /// - Returns: an array of all the file names that are directories in the specific path.
   class func getDirectoryContentPathNames(relativePath: String) -> [String] {
     var pathNames = [String]()
     do {

--- a/Sources/PRLabelAnalysis.swift
+++ b/Sources/PRLabelAnalysis.swift
@@ -181,10 +181,7 @@ class PRLabelAnalysis {
       }
     } else if labelsFromPaths.count == 1, let label = labelsFromPaths.first {
       // check if there is no title label and update accordingly.
-      var updatedTitle = label + " " + PRData.title
-      if let lastChar = PRData.title.last, lastChar != "." {
-        updatedTitle += "."
-      }
+      let updatedTitle = label + " " + PRData.title
       GithubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
       // notify of title change
       GithubAPI.createComment(url: PRData.issue_url,

--- a/Sources/PRLabelAnalysis.swift
+++ b/Sources/PRLabelAnalysis.swift
@@ -74,4 +74,159 @@ class PRLabelAnalysis {
     return labels
   }
 
+
+  /// This method receives the incoming issue data and adds a [component] label based on the title
+  /// prefix of the issue.
+  ///
+  /// If the [component] title prefix doesn't exist, it writes a comment to notify the submitter.
+  ///
+  /// If the [component] title prefix isn't entirely accurate, it parses the components/ directory and
+  /// finds if there is a close match and updates the title accordingly. It will also notify the
+  /// submitter of the change.
+  ///
+  /// - Parameter issueData: The incoming issue data
+  class func addAndFixLabelsForIssues(issueData: IssueData) {
+    let componentNames = GithubAPI.getDirectoryContentPathNames(relativePath: "/components")
+    var labelsToAdd = [String]()
+    if let titleLabel = PRLabelAnalysis.getTitleLabel(title: issueData.title) {
+      for name in componentNames {
+        let bracketedName = "[" + name + "]"
+        if titleLabel == bracketedName {
+          labelsToAdd.append(titleLabel)
+          break
+        } else if PRLabelAnalysis.checkIfTwoStringsAreSimilar(str1: bracketedName, str2: titleLabel, threshold: 7) {
+          labelsToAdd.append(bracketedName)
+
+          // update title
+          if let range = titleLabel.range(of: "]") {
+            let titleWithoutLabel = titleLabel[range.upperBound...]
+            var updatedTitle = bracketedName
+            if titleWithoutLabel.first != " " {
+              updatedTitle += " " + titleWithoutLabel
+            } else {
+              updatedTitle += titleWithoutLabel
+            }
+            if let lastChar = issueData.title.last, lastChar != "." {
+              updatedTitle += "."
+            }
+            GithubAPI.editIssue(url: issueData.url, issueEdit: ["title": updatedTitle])
+            // notify of title change
+            GithubAPI.createComment(url: issueData.url,
+                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedName)")
+          }
+          break
+        }
+      }
+    }
+    if (labelsToAdd.count > 0) {
+      GithubAPI.addLabelsToIssue(url: issueData.url, labels: Array(Set(labelsToAdd)))
+    } else {
+      GithubAPI.createComment(url: issueData.url,
+                              comment: "The title doesn't have a [Component] prefix.")
+    }
+  }
+
+
+  /// This method receives the incoming pull request data and adds [component] labels based on the
+  /// what files have been modified.
+  ///
+  /// If the [component] title prefix doesn't exist, it writes a comment to notify the submitter, and looks
+  /// at the code diff to figure out if there is a change to only one component and updates the title
+  /// to have that component's label prefix.
+  ///
+  /// If the [component] title prefix isn't entirely accurate, it parses the diff and
+  /// finds if there is a close match and updates the title accordingly. It will also notify the
+  /// submitter of the change.
+  ///
+  /// If there are multiple components being modified, we will comment to let the submitter know
+  /// that multiple components are being modified.
+  ///
+  /// - Parameter PRData: The incoming pull request data
+  class func addAndFixLabelsForPullRequests(PRData: PullRequestData) {
+    var labelsToAdd = [String]()
+    let diffURL = PRData.diff_url
+    let paths = PRLabelAnalysis.getFilePaths(url: diffURL)
+    let labelsFromPaths = Set(PRLabelAnalysis.grabLabelsFromPaths(paths: paths))
+    if (labelsFromPaths.count > 1) {
+      // notify of changing multiple components
+      GithubAPI.createComment(url: PRData.issue_url,
+                              comment: "This PR affects multiple components.")
+    }
+    labelsToAdd.append(contentsOf: labelsFromPaths)
+    if let titleLabel = PRLabelAnalysis.getTitleLabel(title: PRData.title) {
+      // check if there is a title label but it needs fixing.
+      for label in labelsFromPaths {
+        if label == titleLabel {
+          break
+        } else if PRLabelAnalysis.checkIfTwoStringsAreSimilar(str1: titleLabel, str2: label, threshold: 7) {
+          if let range = titleLabel.range(of: "]") {
+            let titleWithoutLabel = titleLabel[range.upperBound...]
+            var updatedTitle = label
+            if titleWithoutLabel.first != " " {
+              updatedTitle += " " + titleWithoutLabel
+            } else {
+              updatedTitle += titleWithoutLabel
+            }
+            if let lastChar = PRData.title.last, lastChar != "." {
+              updatedTitle += "."
+            }
+            GithubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
+            // notify of title change
+            GithubAPI.createComment(url: PRData.issue_url,
+                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(label)")
+          }
+          break
+        }
+      }
+    } else if labelsFromPaths.count == 1, let label = labelsFromPaths.first {
+      // check if there is no title label and update accordingly.
+      var updatedTitle = label + " " + PRData.title
+      if let lastChar = PRData.title.last, lastChar != "." {
+        updatedTitle += "."
+      }
+      GithubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
+      // notify of title change
+      GithubAPI.createComment(url: PRData.issue_url,
+                              comment: "Based on the changes, the title has been prefixed with \(label)")
+    }
+    if (labelsToAdd.count > 0) {
+      GithubAPI.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))
+    }
+  }
+
+  /// This method gets two strings and uses the Levenshtein Distance algorithm to find out how
+  /// similar they are. It is also given a threshold as to how similar they can be and returns
+  /// True if the difference is lower than or equal to the threshold, and False otherwise.
+  /// Every deletion/addition/reorder action is worth 1 "point" of difference.
+  ///
+  /// - Parameters:
+  ///   - str1: The first string to compare
+  ///   - str2: The second string to compare
+  ///   - threshold: The given threshold of allowed difference
+  /// - Returns: returns true if the strings are similar based on the threshold, and false otherwise.
+  class func checkIfTwoStringsAreSimilar(str1: String, str2: String, threshold: Int) -> Bool {
+    var distance = [[Int]]()
+    for _ in 0...str1.count {
+      distance.append(Array(repeating: 0, count: str2.count + 1))
+    }
+    for i in 1...str1.count {
+      distance[i][0] = i
+    }
+    for j in 1...str2.count {
+      distance[0][j] = j
+    }
+    let arr1 = Array(str1)
+    let arr2 = Array(str2)
+    for i in 1...str1.count {
+      for j in 1...str2.count {
+        if arr1[i-1] == arr2[j-1] {
+          distance[i][j] = distance[i-1][j-1]
+        } else {
+          distance[i][j] = min(distance[i-1][j], distance[i][j-1], distance[i-1][j-1]) + 1
+        }
+      }
+    }
+    return distance[str1.count][str2.count] <= threshold
+  }
+
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -72,11 +72,11 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
 
   if let PRData = githubData?.PRData {
     if githubData?.action == "synchronize" || githubData?.action == "opened" {
-      PRLabelAnalysis.addAndFixLabelsForPullRequests(PRData: PRData)
+      LabelAnalysis.addAndFixLabelsForPullRequests(PRData: PRData)
     }
   } else if let issueData = githubData?.issueData {
     if githubData?.action == "synchronize" || githubData?.action == "opened" {
-      PRLabelAnalysis.addAndFixLabelsForIssues(issueData: issueData)
+      LabelAnalysis.addAndFixLabelsForIssues(issueData: issueData)
     }
   }
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -71,42 +71,12 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
   let githubData = GithubData.createGithubData(from: request.postBodyString!)
 
   if let PRData = githubData?.PRData {
-    // Add Labels to PR flow
     if githubData?.action == "synchronize" || githubData?.action == "opened" {
-      var labelsToAdd = [String]()
-      let diffURL = PRData.diff_url
-      let paths = PRLabelAnalysis.getFilePaths(url: diffURL)
-      let labelsFromPaths = Set(PRLabelAnalysis.grabLabelsFromPaths(paths: paths))
-      if (labelsFromPaths.count > 1) {
-        //notify of changing multiple components
-        GithubAPI.createComment(url: PRData.issue_url, comment: "This PR affects multiple components.")
-      }
-      labelsToAdd.append(contentsOf: labelsFromPaths)
-      if let titleLabel = PRLabelAnalysis.getTitleLabel(title: PRData.title) {
-        labelsToAdd.append(titleLabel)
-      } else if labelsFromPaths.count == 1, let label = labelsFromPaths.first {
-        //update title
-        GithubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": label + PRData.title])
-        //notify of title change
-        GithubAPI.createComment(url: PRData.issue_url,
-                                comment: "Based on the changes, the title has been prefixed with \(label)")
-      }
-      if (labelsToAdd.count > 0) {
-        GithubAPI.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))
-      }
+      PRLabelAnalysis.addAndFixLabelsForPullRequests(PRData: PRData)
     }
   } else if let issueData = githubData?.issueData {
-    // Add Labels to Issue flow
     if githubData?.action == "synchronize" || githubData?.action == "opened" {
-      var labelsToAdd = [String]()
-      if let titleLabel = PRLabelAnalysis.getTitleLabel(title: issueData.title) {
-        labelsToAdd.append(titleLabel)
-      }
-      if (labelsToAdd.count > 0) {
-        GithubAPI.addLabelsToIssue(url: issueData.url, labels: Array(Set(labelsToAdd)))
-      } else {
-        GithubAPI.createComment(url: issueData.url, comment: "The title doesn't have a [Component] prefix.")
-      }
+      PRLabelAnalysis.addAndFixLabelsForIssues(issueData: issueData)
     }
   }
 


### PR DESCRIPTION
* Moved all the labeling analysis out of main.swift so it can be left for more the incoming HTTP request logic and routing.
* Now if a PR or an Issue has some typos in its [component] prefix, it will find out the Levenshtein difference (https://en.wikipedia.org/wiki/Levenshtein_distance) between the title prefix and the existing component names and if they are similar enough it will update the title. It will also notify the submitter with a comment about the change.
* Now if we use [blabla] in the title of a PR and it's not close enough to any component name, no new label will be created for it.

This resolves issue #9 