### PR TITLE
Adding support for multiple repos; adding config file for repo specific params

### DIFF
--- a/Config.plist
+++ b/Config.plist
@@ -4,15 +4,11 @@
 <dict>
 	<key>CLOUD_STORAGE_BUCKET</key>
 	<string>material-automation.appspot.com</string>
-	<key>GITHUB_REPO_PATH</key>
-	<string>material-components/material-components-ios</string>
 	<key>GITHUB_APP_ID</key>
-	<string>10819</string>
+	<string>11993</string>
 	<key>PEM_FILE_NAME</key>
-	<string>githubKey.pem</string>
+	<string>GithubKeyDebug.pem</string>
 	<key>USER_AGENT</key>
 	<string>Material Automation</string>
-	<key>PRODUCTION_PATH</key>
-	<string>/root/MaterialAutomation/</string>
 </dict>
 </plist>

--- a/Config.plist
+++ b/Config.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLOUD_STORAGE_BUCKET</key>
+	<string>material-automation.appspot.com</string>
+	<key>GITHUB_REPO_PATH</key>
+	<string>material-components/material-components-ios</string>
+	<key>GITHUB_APP_ID</key>
+	<string>10819</string>
+	<key>PEM_FILE_NAME</key>
+	<string>githubKey.pem</string>
+	<key>USER_AGENT</key>
+	<string>Material Automation</string>
+	<key>PRODUCTION_PATH</key>
+	<string>/root/MaterialAutomation/</string>
+</dict>
+</plist>

--- a/Config.plist
+++ b/Config.plist
@@ -5,9 +5,9 @@
 	<key>CLOUD_STORAGE_BUCKET</key>
 	<string>material-automation.appspot.com</string>
 	<key>GITHUB_APP_ID</key>
-	<string>11993</string>
+	<string>10819</string>
 	<key>PEM_FILE_NAME</key>
-	<string>GithubKeyDebug.pem</string>
+	<string>GithubKey.pem</string>
 	<key>USER_AGENT</key>
 	<string>Material Automation</string>
 </dict>

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ EXPOSE 8080
 RUN mkdir /root/MaterialAutomation
 ADD Package.swift /root/MaterialAutomation
 ADD Sources /root/MaterialAutomation/Sources
-ADD GithubKeyDebug.pem /root/MaterialAutomation
+ADD GithubKey.pem /root/MaterialAutomation
 ADD Config.plist /root/MaterialAutomation
 
 # Build the app

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ EXPOSE 8080
 RUN mkdir /root/MaterialAutomation
 ADD Package.swift /root/MaterialAutomation
 ADD Sources /root/MaterialAutomation/Sources
-ADD material-ci-app.2018-05-09.private-key.pem /root/MaterialAutomation
+ADD GithubKeyDebug.pem /root/MaterialAutomation
 ADD Config.plist /root/MaterialAutomation
 
 # Build the app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir /root/MaterialAutomation
 ADD Package.swift /root/MaterialAutomation
 ADD Sources /root/MaterialAutomation/Sources
 ADD material-ci-app.2018-05-09.private-key.pem /root/MaterialAutomation
+ADD Config.plist /root/MaterialAutomation
 
 # Build the app
 RUN cd /root/MaterialAutomation && ls -la && cd Sources && ls -la

--- a/Sources/ConfigManager.swift
+++ b/Sources/ConfigManager.swift
@@ -1,0 +1,46 @@
+/*
+ Copyright 2018 the Material Automation authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import PerfectLib
+
+struct DefaultConfigParams {
+  static let githubBaseURL = "https://api.github.com"
+  static let projectPath = getProjectDirectory()
+  static let userAgent = "Material Automation"
+  static let helloMessage = "Hello from Material Automation!"
+  static let plistPath = "Config.plist"
+
+  static func getProjectDirectory() -> String {
+    let filePath = #file
+    return "/" + filePath.split(separator: "/").dropLast(2).joined(separator: "/") + "/"
+  }
+}
+
+class ConfigManager {
+
+  static let shared = ConfigManager()
+  let configDict: NSDictionary
+
+  init?() {
+    let file = File(DefaultConfigParams.projectPath + DefaultConfigParams.plistPath)
+    guard file.exists, let dict = NSDictionary(contentsOfFile: file.realPath) else {
+        return nil
+    }
+    configDict = dict
+  }
+
+}

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -48,7 +48,6 @@ class GithubCURLRequest: CURLRequest {
 }
 
 public class GithubAPI {
-  static let githubBaseURL = "https://api.github.com"
   static let retryCount = 0
   static var lastGithubAccess = time(nil)
 
@@ -121,12 +120,12 @@ public class GithubAPI {
   /// This method bulk updates all the existing Github issues to have labels through the API.
   class func setLabelsForAllIssues() {
     do {
-      guard let repoPath = ProcessInfo.processInfo.environment["GITHUB_REPO_PATH"] else {
+      guard let repoPath = ConfigManager.shared?.configDict["GITHUB_REPO_PATH"] as? String else {
         LogFile.error("You have not defined a GITHUB_REPO_PATH pointing to your repo in your app.yaml file")
         return
       }
       let relativePathForRepo = "/repos/" + repoPath
-      let issuesURL = githubBaseURL + relativePathForRepo + "/issues"
+      let issuesURL = DefaultConfigParams.githubBaseURL + relativePathForRepo + "/issues"
       let params = "?state=all"
       let request = GithubCURLRequest(issuesURL + params)
       addAPIHeaders(to: request)
@@ -201,11 +200,12 @@ public class GithubAPI {
 // API Headers
 extension GithubAPI {
   class func githubAPIHTTPHeaders() -> [String: String] {
+    let userAgent = ConfigManager.shared?.configDict["USER_AGENT"] as? String ?? DefaultConfigParams.userAgent
     var headers = [String: String]()
     headers["Authorization"] = "token \(GithubAuth.accessToken)"
     LogFile.debug("the access token is: \(GithubAuth.accessToken)")
     headers["Accept"] = "application/vnd.github.machine-man-preview+json"
-    headers["User-Agent"] = "Material Automation"
+    headers["User-Agent"] = userAgent
     return headers
   }
 

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -212,7 +212,6 @@ public class GithubAPI {
   /// - Returns: an array of all the file names that are directories in the specific path.
   func getDirectoryContentPathNames(relativePath: String, repoURL: String) -> [String] {
     var pathNames = [String]()
-
     let performRequest = { () -> CURLResponse in
       let contentsAPIPath = repoURL + "/contents/" + relativePath
       let request = GithubCURLRequest(contentsAPIPath)

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -162,16 +162,10 @@ public class GithubAPI {
 
 
   /// This method bulk updates all the existing Github issues to have labels through the API.
-  func setLabelsForAllIssues() {
-
-    guard let repoPath = ConfigManager.shared?.configDict["GITHUB_REPO_PATH"] as? String else {
-      LogFile.error("You have not defined a GITHUB_REPO_PATH pointing to your repo in your app.yaml file")
-      return
-    }
+  func setLabelsForAllIssues(repoURL: String) {
 
     let performRequest = { () -> CURLResponse in
-      let relativePathForRepo = "/repos/" + repoPath
-      let issuesURL = DefaultConfigParams.githubBaseURL + relativePathForRepo + "/issues"
+      let issuesURL = repoURL + "/issues"
       let params = "?state=all"
       let request = GithubCURLRequest(issuesURL + params)
       self.addAPIHeaders(to: request)
@@ -216,15 +210,11 @@ public class GithubAPI {
   ///
   /// - Parameter relativePath: The relative path inside the repository source code
   /// - Returns: an array of all the file names that are directories in the specific path.
-  func getDirectoryContentPathNames(relativePath: String) -> [String] {
+  func getDirectoryContentPathNames(relativePath: String, repoURL: String) -> [String] {
     var pathNames = [String]()
-    guard let repoPath = ProcessInfo.processInfo.environment["GITHUB_REPO_PATH"] else {
-      LogFile.error("You have not defined a GITHUB_REPO_PATH pointing to your repo in your app.yaml file")
-      return pathNames
-    }
 
     let performRequest = { () -> CURLResponse in
-      let contentsAPIPath = DefaultConfigParams.githubBaseURL + "/repos/" + repoPath + "/contents/" + relativePath
+      let contentsAPIPath = repoURL + "/contents/" + relativePath
       let request = GithubCURLRequest(contentsAPIPath)
       self.addAPIHeaders(to: request)
       return try request.perform()

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -45,7 +45,7 @@ class GithubManager {
         LogFile.error("couldn't get an access token for installation: \(installation)")
         return nil
       }
-      let githubInstance = GithubAPI(accessToken: accessToken)
+      let githubInstance = GithubAPI(accessToken: accessToken, installationID: installation)
       githubInstances[accessToken] = githubInstance
       return githubInstance
     }
@@ -72,11 +72,13 @@ class GithubCURLRequest: CURLRequest {
 public class GithubAPI {
 
   var accessToken: String
+  var installationID: String
   let curlAccessLock = Threading.Lock()
   var lastGithubAccess = time(nil)
 
-  init(accessToken: String) {
+  init(accessToken: String, installationID: String) {
     self.accessToken = accessToken
+    self.installationID = installationID
   }
 
   /// This method adds labels to a Github issue through the API.
@@ -96,7 +98,7 @@ public class GithubAPI {
 
     do {
       var response = try performRequest()
-      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response, githubInstance: self) {
         response = try performRequest()
       }
       LogFile.info("request result for addLabels: \(response.bodyString)")
@@ -122,7 +124,7 @@ public class GithubAPI {
 
     do {
       var response = try performRequest()
-      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response, githubInstance: self) {
         response = try performRequest()
       }
       LogFile.info("request result for createComment: \(response.bodyString)")
@@ -149,7 +151,7 @@ public class GithubAPI {
 
     do {
       var response = try performRequest()
-      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response, githubInstance: self) {
         response = try performRequest()
       }
       LogFile.info("request result for editIssue: \(response.bodyString)")
@@ -178,7 +180,7 @@ public class GithubAPI {
 
     do {
       var response = try performRequest()
-      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response, githubInstance: self) {
         response = try performRequest()
       }
       let result = try response.bodyString.jsonDecode() as? [[String: Any]] ?? [[:]]
@@ -230,7 +232,7 @@ public class GithubAPI {
 
     do {
       var response = try performRequest()
-      if GithubAuth.refreshCredentialsIfUnauthorized(response: response) {
+      if GithubAuth.refreshCredentialsIfUnauthorized(response: response, githubInstance: self) {
         response = try performRequest()
       }
       let result = try response.bodyString.jsonDecode() as? [[String: Any]] ?? [[:]]

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -106,11 +106,11 @@ public class GithubAuth {
     return headers
   }
 
-  class func refreshCredentialsIfUnauthorized(response: CURLResponse, githubInstance: GithubAPI) -> Bool {
+  class func refreshCredentialsIfUnauthorized(response: CURLResponse, githubAPI: GithubAPI) -> Bool {
     LogFile.debug("trying to refresh Github credentials")
     for n in 0..<4 {
       if response.responseCode == 401 || response.responseCode == 403 {
-        if refreshGithubCredentials(githubInstance: githubInstance) {
+        if refreshGithubCredentials(githubAPI: githubAPI) {
           LogFile.debug("Refreshed Github credentials!")
           return true
         } else {
@@ -126,17 +126,17 @@ public class GithubAuth {
     return false
   }
 
-  class func refreshGithubCredentials(githubInstance: GithubAPI) -> Bool {
+  class func refreshGithubCredentials(githubAPI: GithubAPI) -> Bool {
     GithubAuth.credentialsLock.lock()
     defer {
       GithubAuth.credentialsLock.unlock()
     }
-    if let accessToken = GithubAuth.getAccessToken(installationID: githubInstance.installationID) {
+    if let accessToken = GithubAuth.getAccessToken(installationID: githubAPI.installationID) {
       LogFile.debug("the access token is good: \(accessToken)")
-      githubInstance.accessToken = accessToken
+      githubAPI.accessToken = accessToken
       return true
     }
-    LogFile.error("Cannot Authenticate with Github for this installation: \(githubInstance.installationID)")
+    LogFile.error("Cannot Authenticate with Github for this installation: \(githubAPI.installationID)")
     return false
   }
 

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -63,7 +63,9 @@ public class GithubAuth {
     do {
       let request = CURLRequest(DefaultConfigParams.githubBaseURL + "/app/installations/" + installationID)
       addAuthHeaders(to: request)
-      let json = try request.perform().bodyString.jsonDecode() as? [String: Any] ?? [:]
+      let test = try request.perform().bodyString
+      LogFile.debug(test)
+      let json = try test.jsonDecode() as? [String: Any] ?? [:]
       return json["access_tokens_url"] as? String
     } catch {
       LogFile.error("error: \(error) desc: \(error.localizedDescription)")

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -131,19 +131,12 @@ public class GithubAuth {
     defer {
       GithubAuth.credentialsLock.unlock()
     }
-    do {
-      if let accessToken = GithubAuth.getAccessToken(installationID: githubInstance.installationID) {
-        LogFile.debug("the access token is good: \(accessToken)")
-        githubInstance.accessToken = accessToken
-        return true
-      } else {
-        LogFile.error("Cannot Authenticate with Github for this installation: \(githubInstance.installationID)")
-        return false
-      }
-    } catch {
-      LogFile.error("Cannot Authenticate with Github: \(error)")
+    if let accessToken = GithubAuth.getAccessToken(installationID: githubInstance.installationID) {
+      LogFile.debug("the access token is good: \(accessToken)")
+      githubInstance.accessToken = accessToken
+      return true
     }
-
+    LogFile.error("Cannot Authenticate with Github for this installation: \(githubInstance.installationID)")
     return false
   }
 

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -30,7 +30,7 @@ public class GithubAuth {
     guard let githubAppIDStr = ConfigManager.shared?.configDict["GITHUB_APP_ID"] as? String,
       let pemFileName = ConfigManager.shared?.configDict["PEM_FILE_NAME"] as? String,
       let githubAppID = Int(githubAppIDStr) else {
-      LogFile.error("You have not defined GITHUB_APP_ID in your app.yaml file")
+      LogFile.error("You have not defined GITHUB_APP_ID or PEM_FILE_NAME in your app.yaml file")
       return ""
     }
     let fileDirectory = DefaultConfigParams.projectPath
@@ -48,6 +48,12 @@ public class GithubAuth {
   }
 
   class func getAccessToken(installationID: String) -> String? {
+    do {
+      _ = try GithubAuth.signAndEncodeJWT()
+      LogFile.debug("the JWT token is good: \(GithubAuth.JWTToken != "")")
+    } catch {
+      LogFile.error("error: \(error) desc: \(error.localizedDescription)")
+    }
 
     guard let accessTokenURL = getInstallationAccessTokenURL(installationID: installationID) else {
       LogFile.error("Could not retrieve the access token URL for the installation ID: \(installationID)")
@@ -128,8 +134,6 @@ public class GithubAuth {
       GithubAuth.credentialsLock.unlock()
     }
     do {
-      _ = try GithubAuth.signAndEncodeJWT()
-      LogFile.debug("the JWT token is good: \(GithubAuth.JWTToken != "")")
       if let accessToken = GithubAuth.getAccessToken(installationID: githubInstance.installationID) {
         LogFile.debug("the access token is good: \(accessToken)")
         githubInstance.accessToken = accessToken

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -65,10 +65,7 @@ public class GithubAuth {
     return nil
   }
 
-  class func getAccessToken(installationID: String, checkCached: Bool) -> String? {
-    if checkCached, let accessToken = UserDefaults.standard.string(forKey: installationID) {
-      return accessToken
-    }
+  class func getAccessToken(installationID: String) -> String? {
 
     guard let accessTokenURL = getInstallationAccessTokenURL(installationID: installationID) else {
       LogFile.error("Could not retrieve the access token URL for the installation ID: \(installationID)")

--- a/Sources/GithubAuth.swift
+++ b/Sources/GithubAuth.swift
@@ -69,9 +69,7 @@ public class GithubAuth {
     do {
       let request = CURLRequest(DefaultConfigParams.githubBaseURL + "/app/installations/" + installationID)
       addAuthHeaders(to: request)
-      let test = try request.perform().bodyString
-      LogFile.debug(test)
-      let json = try test.jsonDecode() as? [String: Any] ?? [:]
+      let json = try request.perform().bodyString.jsonDecode() as? [String: Any] ?? [:]
       return json["access_tokens_url"] as? String
     } catch {
       LogFile.error("error: \(error) desc: \(error.localizedDescription)")

--- a/Sources/GithubData.swift
+++ b/Sources/GithubData.swift
@@ -30,7 +30,10 @@ public class GithubData : JSONConvertibleObject, CustomStringConvertible {
 
   init(installation: [String: Any]?, action: String, PRData: [String: Any]?, issueData: [String: Any]?) {
     if let installation = installation {
-      self.installationID = installation["id"] as? String
+      LogFile.debug(installation.description)
+      if let installationNum = installation["id"] as? Int {
+        self.installationID = "\(installationNum)"
+      }
     }
     self.action = action
     if let PRData = PRData {
@@ -42,6 +45,7 @@ public class GithubData : JSONConvertibleObject, CustomStringConvertible {
   }
 
   public override func setJSONValues(_ values: [String : Any]) {
+    LogFile.debug("debugging this: \(values.description)")
     let installationDict: [String: Any]? =
       getJSONValue(named: "installation", from: values, defaultValue: nil)
     self.installationID = installationDict?["id"] as? String

--- a/Sources/GithubData.swift
+++ b/Sources/GithubData.swift
@@ -159,6 +159,8 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
   var body: String = ""
   var labels: [String] = [String]()
   var url: String = ""
+  var repo_url: String = ""
+
   public var description: String {
     return "IssueData: id:\(id), title:\(title), body:\(body), state:\(state)"
   }
@@ -169,7 +171,8 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
        title: String,
        body: String,
        labels: [String],
-       url: String) {
+       url: String,
+       repo_url: String) {
     self.id = id
     self.html_url = html_url
     self.state = state
@@ -177,6 +180,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
     self.body = body
     self.labels = labels
     self.url = url
+    self.repo_url = repo_url
   }
 
   public override func setJSONValues(_ values: [String : Any]) {
@@ -187,6 +191,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
     self.body = getJSONValue(named: "body", from: values, defaultValue: "")
     self.labels = getJSONValue(named: "labels", from: values, defaultValue: [String]())
     self.url = getJSONValue(named: "url", from: values, defaultValue: "")
+    self.repo_url = getJSONValue(named: "repo_url", from: values, defaultValue: "")
   }
 
   public override func getJSONValues() -> [String : Any] {
@@ -197,7 +202,8 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
        "title": title,
        "body": body,
        "labels": labels,
-       "url": url
+       "url": url,
+       "repo_url": repo_url
     ]
   }
 
@@ -208,7 +214,8 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
                      title: dict["title"] as? String ?? "",
                      body: dict["body"] as? String ?? "",
                      labels: dict["labels"] as? [String] ?? [String](),
-                     url: dict["url"] as? String ?? "")
+                     url: dict["url"] as? String ?? "",
+                     repo_url: dict["repo_url"] as? String ?? "")
   }
 
 }

--- a/Sources/GithubData.swift
+++ b/Sources/GithubData.swift
@@ -163,7 +163,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
   var body: String = ""
   var labels: [String] = [String]()
   var url: String = ""
-  var repo_url: String = ""
+  var repository_url: String = ""
 
   public var description: String {
     return "IssueData: id:\(id), title:\(title), body:\(body), state:\(state)"
@@ -176,7 +176,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
        body: String,
        labels: [String],
        url: String,
-       repo_url: String) {
+       repository_url: String) {
     self.id = id
     self.html_url = html_url
     self.state = state
@@ -184,7 +184,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
     self.body = body
     self.labels = labels
     self.url = url
-    self.repo_url = repo_url
+    self.repository_url = repository_url
   }
 
   public override func setJSONValues(_ values: [String : Any]) {
@@ -195,7 +195,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
     self.body = getJSONValue(named: "body", from: values, defaultValue: "")
     self.labels = getJSONValue(named: "labels", from: values, defaultValue: [String]())
     self.url = getJSONValue(named: "url", from: values, defaultValue: "")
-    self.repo_url = getJSONValue(named: "repo_url", from: values, defaultValue: "")
+    self.repository_url = getJSONValue(named: "repository_url", from: values, defaultValue: "")
   }
 
   public override func getJSONValues() -> [String : Any] {
@@ -207,7 +207,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
        "body": body,
        "labels": labels,
        "url": url,
-       "repo_url": repo_url
+       "repository_url": repository_url
     ]
   }
 
@@ -219,7 +219,7 @@ public class IssueData: JSONConvertibleObject, CustomStringConvertible {
                      body: dict["body"] as? String ?? "",
                      labels: dict["labels"] as? [String] ?? [String](),
                      url: dict["url"] as? String ?? "",
-                     repo_url: dict["repo_url"] as? String ?? "")
+                     repository_url: dict["repository_url"] as? String ?? "")
   }
 
 }

--- a/Sources/GithubData.swift
+++ b/Sources/GithubData.swift
@@ -30,7 +30,6 @@ public class GithubData : JSONConvertibleObject, CustomStringConvertible {
 
   init(installation: [String: Any]?, action: String, PRData: [String: Any]?, issueData: [String: Any]?) {
     if let installation = installation {
-      LogFile.debug(installation.description)
       if let installationNum = installation["id"] as? Int {
         self.installationID = "\(installationNum)"
       }
@@ -45,7 +44,6 @@ public class GithubData : JSONConvertibleObject, CustomStringConvertible {
   }
 
   public override func setJSONValues(_ values: [String : Any]) {
-    LogFile.debug("debugging this: \(values.description)")
     let installationDict: [String: Any]? =
       getJSONValue(named: "installation", from: values, defaultValue: nil)
     self.installationID = installationDict?["id"] as? String

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -87,7 +87,7 @@ class LabelAnalysis {
   /// - Parameter issueData: The incoming issue data
   class func addAndFixLabelsForIssues(issueData: IssueData, githubInstance: GithubAPI) {
     let componentNames = githubInstance.getDirectoryContentPathNames(relativePath: "components",
-                                                                     repoURL: issueData.repo_url)
+                                                                     repoURL: issueData.repository_url)
     var labelsToAdd = [String]()
     let titleLabel = getTitleLabel(title: issueData.title)
     if let titleLabel = titleLabel {

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -86,7 +86,8 @@ class LabelAnalysis {
   ///
   /// - Parameter issueData: The incoming issue data
   class func addAndFixLabelsForIssues(issueData: IssueData, githubInstance: GithubAPI) {
-    let componentNames = githubInstance.getDirectoryContentPathNames(relativePath: "components")
+    let componentNames = githubInstance.getDirectoryContentPathNames(relativePath: "components",
+                                                                     repoURL: issueData.repo_url)
     var labelsToAdd = [String]()
     let titleLabel = getTitleLabel(title: issueData.title)
     if let titleLabel = titleLabel {

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -85,10 +85,11 @@ class LabelAnalysis {
   /// submitter of the change.
   ///
   /// - Parameter issueData: The incoming issue data
-  class func addAndFixLabelsForIssues(issueData: IssueData) {
-    let componentNames = GithubAPI.getDirectoryContentPathNames(relativePath: "components")
+  class func addAndFixLabelsForIssues(issueData: IssueData, installation: String) {
+    let componentNames = GithubAPI.getDirectoryContentPathNames(relativePath: "components",
+                                                                installation: installation)
     var labelsToAdd = [String]()
-    let titleLabel = getTitleLabel(title: issueData.title)
+    let titleLabel = getTitleLabel(title: issueData.title, installation: installation)
     if let titleLabel = titleLabel {
       let unbracketedTitleLabel = String(titleLabel.dropFirst().dropLast())
       // Check if title label is a component name
@@ -119,19 +120,25 @@ class LabelAnalysis {
             } else {
               updatedTitle += titleWithoutLabel
             }
-            GithubAPI.editIssue(url: issueData.url, issueEdit: ["title": updatedTitle])
+            GithubAPI.editIssue(url: issueData.url,
+                                issueEdit: ["title": updatedTitle],
+                                installation: installation)
             // notify of title change
             GithubAPI.createComment(url: issueData.url,
-                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedLabel).")
+                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedName).",
+                                    installation: installation)
           }
         }
       }
     }
     if (labelsToAdd.count > 0) {
-      GithubAPI.addLabelsToIssue(url: issueData.url, labels: Array(Set(labelsToAdd)))
+      GithubAPI.addLabelsToIssue(url: issueData.url,
+                                 labels: Array(Set(labelsToAdd)),
+                                 installation: installation)
     } else if titleLabel == nil {
       GithubAPI.createComment(url: issueData.url,
-                              comment: "The title doesn't have a [Component] prefix.")
+                              comment: "The title doesn't have a [Component] prefix.",
+                              installation: installation)
     }
   }
 
@@ -151,7 +158,7 @@ class LabelAnalysis {
   /// that multiple components are being modified.
   ///
   /// - Parameter PRData: The incoming pull request data
-  class func addAndFixLabelsForPullRequests(PRData: PullRequestData) {
+  class func addAndFixLabelsForPullRequests(PRData: PullRequestData, installation: String) {
     var labelsToAdd = [String]()
     let diffURL = PRData.diff_url
     let paths = getFilePaths(url: diffURL)
@@ -240,10 +247,10 @@ class LabelAnalysis {
   }
 
   /// Adds a "Needs actionability review" label to the issue.
-  class func addNeedsActionabilityReviewLabel(issueData: IssueData) {
+  class func addNeedsActionabilityReviewLabel(issueData: IssueData, installation: String) {
     let actionabilityLabel = "Needs actionability review"
     if !issueData.labels.contains(where: { $0 == actionabilityLabel }) {
-      GithubAPI.addLabelsToIssue(url: issueData.url, labels: [actionabilityLabel])
+      GithubAPI.addLabelsToIssue(url: issueData.url, labels: [actionabilityLabel], installation: String)
     }
   }
 }

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -124,7 +124,7 @@ class LabelAnalysis {
                                      issueEdit: ["title": updatedTitle])
             // notify of title change
             githubInstance.createComment(url: issueData.url,
-                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedName).")
+                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedLabel).")
           }
         }
       }
@@ -191,8 +191,8 @@ class LabelAnalysis {
             }
             githubInstance.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
             // notify of title change
-            GithubAPI.createComment(url: PRData.issue_url,
-                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(lbl).")
+            githubInstance.createComment(url: PRData.issue_url,
+                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(lbl).")
           }
         }
       }

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -85,9 +85,9 @@ class LabelAnalysis {
   /// submitter of the change.
   ///
   /// - Parameter issueData: The incoming issue data
-  class func addAndFixLabelsForIssues(issueData: IssueData, githubInstance: GithubAPI) {
-    let componentNames = githubInstance.getDirectoryContentPathNames(relativePath: "components",
-                                                                     repoURL: issueData.repository_url)
+  class func addAndFixLabelsForIssues(issueData: IssueData, githubAPI: GithubAPI) {
+    let componentNames = githubAPI.getDirectoryContentPathNames(relativePath: "components",
+                                                                repoURL: issueData.repository_url)
     var labelsToAdd = [String]()
     let titleLabel = getTitleLabel(title: issueData.title)
     if let titleLabel = titleLabel {
@@ -120,21 +120,21 @@ class LabelAnalysis {
             } else {
               updatedTitle += titleWithoutLabel
             }
-            githubInstance.editIssue(url: issueData.url,
-                                     issueEdit: ["title": updatedTitle])
+            githubAPI.editIssue(url: issueData.url,
+                                issueEdit: ["title": updatedTitle])
             // notify of title change
-            githubInstance.createComment(url: issueData.url,
-                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedLabel).")
+            githubAPI.createComment(url: issueData.url,
+                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedLabel).")
           }
         }
       }
     }
     if (labelsToAdd.count > 0) {
-      githubInstance.addLabelsToIssue(url: issueData.url,
-                                      labels: Array(Set(labelsToAdd)))
+      githubAPI.addLabelsToIssue(url: issueData.url,
+                                 labels: Array(Set(labelsToAdd)))
     } else if titleLabel == nil {
-      githubInstance.createComment(url: issueData.url,
-                                   comment: "The title doesn't have a [Component] prefix.")
+      githubAPI.createComment(url: issueData.url,
+                              comment: "The title doesn't have a [Component] prefix.")
     }
   }
 
@@ -154,15 +154,15 @@ class LabelAnalysis {
   /// that multiple components are being modified.
   ///
   /// - Parameter PRData: The incoming pull request data
-  class func addAndFixLabelsForPullRequests(PRData: PullRequestData, githubInstance: GithubAPI) {
+  class func addAndFixLabelsForPullRequests(PRData: PullRequestData, githubAPI: GithubAPI) {
     var labelsToAdd = [String]()
     let diffURL = PRData.diff_url
     let paths = getFilePaths(url: diffURL)
     let labelsFromPaths = Set(grabLabelsFromPaths(paths: paths))
     if (labelsFromPaths.count > 1) {
       // notify of changing multiple components
-      githubInstance.createComment(url: PRData.issue_url,
-                                   comment: "This PR affects multiple components.")
+      githubAPI.createComment(url: PRData.issue_url,
+                              comment: "This PR affects multiple components.")
     }
     labelsToAdd.append(contentsOf: labelsFromPaths)
     if let titleLabel = getTitleLabel(title: PRData.title) {
@@ -189,23 +189,23 @@ class LabelAnalysis {
             } else {
               updatedTitle += titleWithoutLabel
             }
-            githubInstance.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
+            githubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
             // notify of title change
-            githubInstance.createComment(url: PRData.issue_url,
-                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(lbl).")
+            githubAPI.createComment(url: PRData.issue_url,
+                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(lbl).")
           }
         }
       }
     } else if labelsFromPaths.count == 1, let label = labelsFromPaths.first {
       // check if there is no title label and update accordingly.
       let updatedTitle = label + " " + PRData.title
-      githubInstance.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
+      githubAPI.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
       // notify of title change
-      githubInstance.createComment(url: PRData.issue_url,
-                                   comment: "Based on the changes, the title has been prefixed with \(label).")
+      githubAPI.createComment(url: PRData.issue_url,
+                              comment: "Based on the changes, the title has been prefixed with \(label).")
     }
     if (labelsToAdd.count > 0) {
-      githubInstance.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))
+      githubAPI.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))
     }
   }
 
@@ -243,10 +243,10 @@ class LabelAnalysis {
   }
 
   /// Adds a "Needs actionability review" label to the issue.
-  class func addNeedsActionabilityReviewLabel(issueData: IssueData, githubInstance: GithubAPI) {
+  class func addNeedsActionabilityReviewLabel(issueData: IssueData, githubAPI: GithubAPI) {
     let actionabilityLabel = "Needs actionability review"
     if !issueData.labels.contains(where: { $0 == actionabilityLabel }) {
-      githubInstance.addLabelsToIssue(url: issueData.url, labels: [actionabilityLabel])
+      githubAPI.addLabelsToIssue(url: issueData.url, labels: [actionabilityLabel])
     }
   }
 }

--- a/Sources/LabelAnalysis.swift
+++ b/Sources/LabelAnalysis.swift
@@ -120,20 +120,20 @@ class LabelAnalysis {
               updatedTitle += titleWithoutLabel
             }
             githubInstance.editIssue(url: issueData.url,
-                                issueEdit: ["title": updatedTitle])
+                                     issueEdit: ["title": updatedTitle])
             // notify of title change
             githubInstance.createComment(url: issueData.url,
-                                    comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedName).")
+                                         comment: "Your title label prefix has been renamed from \(titleLabel) to \(bracketedName).")
           }
         }
       }
     }
     if (labelsToAdd.count > 0) {
       githubInstance.addLabelsToIssue(url: issueData.url,
-                                 labels: Array(Set(labelsToAdd)))
+                                      labels: Array(Set(labelsToAdd)))
     } else if titleLabel == nil {
       githubInstance.createComment(url: issueData.url,
-                              comment: "The title doesn't have a [Component] prefix.")
+                                   comment: "The title doesn't have a [Component] prefix.")
     }
   }
 
@@ -161,7 +161,7 @@ class LabelAnalysis {
     if (labelsFromPaths.count > 1) {
       // notify of changing multiple components
       githubInstance.createComment(url: PRData.issue_url,
-                              comment: "This PR affects multiple components.")
+                                   comment: "This PR affects multiple components.")
     }
     labelsToAdd.append(contentsOf: labelsFromPaths)
     if let titleLabel = getTitleLabel(title: PRData.title) {
@@ -201,7 +201,7 @@ class LabelAnalysis {
       githubInstance.editIssue(url: PRData.issue_url, issueEdit: ["title": updatedTitle])
       // notify of title change
       githubInstance.createComment(url: PRData.issue_url,
-                              comment: "Based on the changes, the title has been prefixed with \(label).")
+                                   comment: "Based on the changes, the title has been prefixed with \(label).")
     }
     if (labelsToAdd.count > 0) {
       githubInstance.addLabelsToIssue(url: PRData.issue_url, labels: Array(Set(labelsToAdd)))

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -54,7 +54,7 @@ routes.add(method: .post, uri: "/labels/updateall", handler: { request, response
       return
   }
 
-  guard let githubAPI = GithubManager.shared.addGithubInstance(for: installationID) else {
+  guard let githubAPI = GithubManager.shared.getGithubInstance(for: installationID) else {
     LogFile.error("could not get a github instance with an access token for \(installationID)")
     response.completed(status: .unauthorized)
     return
@@ -85,7 +85,7 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
     return
   }
 
-  guard let githubAPI = GithubManager.shared.addGithubInstance(for: installationID) else {
+  guard let githubAPI = GithubManager.shared.getGithubInstance(for: installationID) else {
     LogFile.error("could not get a github instance with an access token for \(installationID)")
     response.completed(status: .unauthorized)
     return

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -92,7 +92,6 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       return
   }
 
-  LogFile.debug(bodyString)
   guard let githubData = GithubData.createGithubData(from: bodyString),
   let installationID = githubData.installationID else {
     LogFile.error("couldn't parse incoming webhook request")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -40,7 +40,7 @@ routes.add(method: .get, uri: "/_ah/health", handler: { request, response in
 // Basic GET request
 routes.add(method: .get, uri: "/hello", handler: { request, response in
   LogFile.info("GET - /hello route handler...")
-  response.setBody(string: "Hello from Swift on Google App Engine flexible environment!")
+  response.setBody(string: DefaultConfigParams.helloMessage)
   response.completed()
 })
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -92,6 +92,7 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       return
   }
 
+  LogFile.debug(bodyString)
   guard let githubData = GithubData.createGithubData(from: bodyString),
   let installationID = githubData.installationID else {
     LogFile.error("couldn't parse incoming webhook request")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -48,8 +48,22 @@ routes.add(method: .post, uri: "/labels/updateall", handler: { request, response
   LogFile.info("/labels/updateall")
 
   guard let password = request.header(.authorization),
-    GithubAuth.verifyGooglerPassword(googlerPassword: password),
-    let installationID = request.postBodyString else {
+    GithubAuth.verifyGooglerPassword(googlerPassword: password) else {
+      response.completed(status: .unauthorized)
+      return
+  }
+
+  var json: [String: Any]
+  do {
+    json = try request.postBodyString?.jsonDecode() as? [String: Any] ?? [String: Any]()
+  } catch {
+    response.completed(status: .unauthorized)
+    return
+  }
+
+  guard let installationID = json["installation"] as? String,
+    let repoURL = json["repository_url"] as? String else {
+      LogFile.error("The incoming request is missing information: \(json.description)")
       response.completed(status: .unauthorized)
       return
   }
@@ -61,7 +75,7 @@ routes.add(method: .post, uri: "/labels/updateall", handler: { request, response
   }
 
   Threading.getDefaultQueue().dispatch {
-    githubAPI.setLabelsForAllIssues()
+    githubAPI.setLabelsForAllIssues(repoURL: repoURL)
   }
   response.completed()
 })

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -68,7 +68,7 @@ routes.add(method: .post, uri: "/labels/updateall", handler: { request, response
       return
   }
 
-  guard let githubAPI = GithubManager.shared.getGithubInstance(for: installationID) else {
+  guard let githubAPI = GithubManager.shared.getGithubAPI(for: installationID) else {
     LogFile.error("could not get a github instance with an access token for \(installationID)")
     response.completed(status: .unauthorized)
     return
@@ -99,7 +99,7 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
     return
   }
 
-  guard let githubAPI = GithubManager.shared.getGithubInstance(for: installationID) else {
+  guard let githubAPI = GithubManager.shared.getGithubAPI(for: installationID) else {
     LogFile.error("could not get a github instance with an access token for \(installationID)")
     response.completed(status: .unauthorized)
     return
@@ -108,14 +108,14 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
   if let PRData = githubData.PRData {
     if githubData.action == "synchronize" || githubData.action == "opened" {
       LabelAnalysis.addAndFixLabelsForPullRequests(PRData: PRData,
-                                                   githubInstance: githubAPI)
+                                                   githubAPI: githubAPI)
     }
   } else if let issueData = githubData.issueData {
     if githubData.action == "synchronize" || githubData.action == "opened" {
       LabelAnalysis.addAndFixLabelsForIssues(issueData: issueData,
-                                             githubInstance: githubAPI)
+                                             githubAPI: githubAPI)
       LabelAnalysis.addNeedsActionabilityReviewLabel(issueData: issueData,
-                                                     githubInstance: githubAPI)
+                                                     githubAPI: githubAPI)
     }
   }
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -122,9 +122,6 @@ server.addRoutes(routes)
 // Set a listen port of 8080
 server.serverPort = 8080
 
-// Set up github credentials
-_ = GithubAuth.refreshGithubCredentials()
-
 do {
   // Launch the HTTP server.
   try server.start()


### PR DESCRIPTION
The server is now more dynamic and configurable. It also has other improvements that I will state below:

* Config.plist has been created for server specific configurations. If it's the GitHub app ID, cloud storage bucket, PEM file location, and other configurable settings.
* There is now a ConfigManager singleton that fetches the configuration from the plist, and there is also a `DefaultConfigParams` struct that has default params to fall back on if none are set for specific things.
* There is now a GithubManager singleton that based on the installationID received from the webhook, creates a github instance that is specific for that repo (installation). So if 2 repos have the Github App installed, it creates 2 instances for the GitHub API, because each repo has a different configuration and a different access_token.
* I removed the recursive logic when a request fails due to being unauthorized. The reason being is that it may in some weird cases go into an infinite loop if the token is refreshed but still it returns as unauthorized. Instead I created a block that builds each request and is invoked initially and once more after refreshing the token.
* I removed the dependency of any need to set a project path, it automatically finds the path by invoking the swift `#file` invocation. (this is done in ConfigManager.getProjectDirectory).
* repository_url has been added to the IssueData class as it is needed for some API calls, and removes the dependency of explicitly telling the server your repo name.

closes #17 #18 