### PR TITLE
When a PR is opened/reopened, add it to the current sprint.

### DIFF
--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -269,9 +269,9 @@ public class GithubAPI {
     return columnID
   }
 
-  func getProjectColumnsCardsURLs(columnsURL: String) -> [String: String] {
+  func getProjectColumns(columnsURL: String) -> [[String: Any]] {
     LogFile.debug("listing project columns with url \(columnsURL)")
-    var columnNameToCardsURL = [String: String]()
+    var columns = [[String: Any]]()
     var url = columnsURL
     var shouldPaginate = false
     while true {
@@ -285,10 +285,7 @@ public class GithubAPI {
         let result = try response.bodyString.jsonDecode() as? [[String: Any]] ?? [[:]]
         for column in result {
           LogFile.debug(column.description)
-          if let columnName = column["name"] as? String,
-            let cardsURL = column["cards_url"] as? String {
-            columnNameToCardsURL[columnName] = cardsURL
-          }
+          columns.append(column)
         }
         if let nextURL = self.paginate(response: response) {
           url = nextURL
@@ -299,6 +296,48 @@ public class GithubAPI {
       }
       if !shouldPaginate {
         break
+      }
+    }
+    return columns
+  }
+
+  func getProjectsForRepo(repoURL: String) -> [[String: Any]] {
+    var projects = [[String: Any]]()
+    var url = "\(repoURL)/projects?state=open"
+    var shouldPaginate = false
+    while true {
+      let performRequest = { () -> CURLResponse in
+        let request = GithubCURLRequest(url)
+        self.addAPIHeaders(to: request,
+                           with: ["Accept": "application/vnd.github.inertia-preview+json"])
+        return try request.perform()
+      }
+      githubRequestTemplate(requestFlow: performRequest, methodName: #function) { response in
+        let results = try response.bodyString.jsonDecode() as? [[String: Any]] ?? [[:]]
+        projects += results
+
+        if let nextURL = self.paginate(response: response) {
+          url = nextURL
+          shouldPaginate = true
+        } else {
+          shouldPaginate = false
+        }
+      }
+      if !shouldPaginate {
+        break
+      }
+    }
+    return projects
+  }
+
+  func getProjectColumnsCardsURLs(columnsURL: String) -> [String: String] {
+    LogFile.debug("listing project columns with url \(columnsURL)")
+    let columns = getProjectColumns(columnsURL: columnsURL)
+    var columnNameToCardsURL = [String: String]()
+    columns.forEach { column in
+      if let columnName = column["name"] as? String,
+        let cardsURL = column["cards_url"] as? String {
+        columnNameToCardsURL[columnName] = cardsURL
       }
     }
     return columnNameToCardsURL

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -112,6 +112,12 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
       LabelAnalysis.addAndFixLabelsForPullRequests(PRData: PRData,
                                                    githubAPI: githubAPI)
     }
+
+    // Add any opened pull requests to the current sprint.
+    if githubData.action == "opened" || githubData.action == "reopened" {
+      ProjectAnalysis.addPullRequestToCurrentSprint(githubData: githubData, githubAPI: githubAPI)
+    }
+
   } else if let issueData = githubData.issueData {
     // Issue data received.
     if githubData.action == "opened" {


### PR DESCRIPTION
Tested using a GitHub payload with the following localhost curl request:

```
curl --header "Content-Type: application/json" -vX POST  http://localhost:8080/webhook -d @test.json
```

Closes https://github.com/material-foundation/material-automation/issues/3