### PR TITLE
Only assign unowned issues when moving to in progress.

### DIFF
--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -407,6 +407,10 @@ public class GithubAPI {
     githubRequestTemplate(requestFlow: performRequest, methodName: #function, resultFlow: nil)
   }
 
+  /// Fetches a single GitHub object from the given url.
+  ///
+  /// - Parameter objectURL: Any singular result, e.g. an Issue, Pull Request, or User.
+  /// - Returns: The returned object parsed into a dictionary, if the request succeeded.
   func getObject(objectURL: String) -> [String: Any]? {
     LogFile.debug("getting object with url: \(objectURL)")
     var object: [String: Any]?
@@ -422,6 +426,10 @@ public class GithubAPI {
     return object
   }
 
+  /// Fetches a single GitHub Issue and returns it's unique identifier.
+  ///
+  /// - Parameter issueURL: A GitHub API issue URL.
+  /// - Returns: The issue's identifier parsed as an Int.
   func getIssueID(issueURL: String) -> Int? {
     LogFile.debug("getting issue ID with url: \(issueURL)")
     let object = getObject(objectURL: issueURL)

--- a/Sources/GithubAPI.swift
+++ b/Sources/GithubAPI.swift
@@ -407,19 +407,25 @@ public class GithubAPI {
     githubRequestTemplate(requestFlow: performRequest, methodName: #function, resultFlow: nil)
   }
 
-  func getIssueID(issueURL: String) -> Int? {
-    LogFile.debug("getting issue ID with url: \(issueURL)")
-    var issueID: Int?
+  func getObject(objectURL: String) -> [String: Any]? {
+    LogFile.debug("getting object with url: \(objectURL)")
+    var object: [String: Any]?
     let performRequest = { () -> CURLResponse in
-      let request = GithubCURLRequest(issueURL)
+      let request = GithubCURLRequest(objectURL)
       self.addAPIHeaders(to: request)
       return try request.perform()
     }
     githubRequestTemplate(requestFlow: performRequest, methodName: #function) { response in
       let result = try response.bodyString.jsonDecode() as? [String: Any] ?? [:]
-      issueID = result["id"] as? Int
+      object = result
     }
-    return issueID
+    return object
+  }
+
+  func getIssueID(issueURL: String) -> Int? {
+    LogFile.debug("getting issue ID with url: \(issueURL)")
+    let object = getObject(objectURL: issueURL)
+    return object?["id"] as? Int
   }
 
 }

--- a/Sources/ProjectAnalysis.swift
+++ b/Sources/ProjectAnalysis.swift
@@ -38,7 +38,12 @@ class ProjectAnalysis {
     if let sender = githubData.sender,
       fromColumnName == "Backlog" && (toColumnName == "In progress" || toColumnName == "Done") {
       //assign issue to user
-      githubAPI.editIssue(url: contentURL, issueEdit: ["assignees": [sender]])
+      let object = githubAPI.getObject(objectURL: contentURL)
+      if let assignees = object?["assignees"] as? [[String: Any]] {
+        if assignees.count == 0 { // Only assign if we can confirm that nobody is already assigned.
+          githubAPI.editIssue(url: contentURL, issueEdit: ["assignees": [sender]])
+        }
+      }
     }
 
     if toColumnName == "Done" {


### PR DESCRIPTION
Before this change, cards that were manually moved from backlog to in progress would be assigned to the mover, regardless of the current assignment status of the issue.

After this change, the card will only be assigned to the mover if the card does not already have an assignment.

Closes https://github.com/material-foundation/material-automation/issues/49