### PR TITLE
Revert signature verification changes from 5a9eefabef0692380afb7f471549acbfc370c2cb.

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -87,8 +87,9 @@ routes.add(method: .post, uri: "/webhook", handler: { request, response in
   LogFile.info("/webhook")
   Analytics.trackEvent(category: "Incoming", action: "/webhook")
 
-  guard
-    let bodyString = request.postBodyString else {
+  guard let sig = request.header(.custom(name: "X-Hub-Signature")),
+    let bodyString = request.postBodyString,
+    GithubAuth.verifyGithubSignature(payload: bodyString, requestSig: sig) else {
       LogFile.error("unauthorized request")
       response.completed(status: .unauthorized)
       return


### PR DESCRIPTION
5a9eefabef0692380afb7f471549acbfc370c2cb had removed the signature verification for localhost testing, but that change wasn't intended to land on develop.